### PR TITLE
Add details to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # Questions
-To add your question raise an issue in this repository.
+
+
+Ask us questions about **anything** related to Open Source! To add your question, create an issue in this repository.
+
+Just a few guidelines to remember before you ask a question:
+
+- Ensure your question hasn't already been answered. If it has been answered but does not satisfy you, feel free to comment in the issue and we will re-open it.
+- Use a succinct title and description.
+- If your question has already been asked and answered adequately, please add a thumbs-up (or the emoji of your choice!) to the issue. This helps us in identifying common problems that people usually face.
+- Lastly, be civil and polite. :)
+


### PR DESCRIPTION
Added a few details to the README.

We could use the :+1: on the issues to identify FAQs and apply a `FAQ` issue label on them. This will help people in going through the issues in future.